### PR TITLE
Fix fall count bug in physics

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -200,13 +200,15 @@ const GameCanvas = ({
 
   // Handle object falling off
   const handleObjectFall = () => {
-    setFallCount((prev) => prev + 1);
-
-    // Game over if too many objects fall
-    if (fallCount >= 2) {
-      setGameState("gameOver");
-      onGameOver();
-    }
+    setFallCount((prev) => {
+      const newCount = prev + 1;
+      // Game over if too many objects fall
+      if (newCount >= 2) {
+        setGameState("gameOver");
+        onGameOver();
+      }
+      return newCount;
+    });
   };
 
   // Reset game state when restarting


### PR DESCRIPTION
## Summary
- fix stale state when counting falls in `GameCanvas`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d405cb048329b08f5f1f566087da